### PR TITLE
fix(frontend): pass commit hash into container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository }}-${{ matrix.context }}
+      - name: Load commit sha (short) into environment
+        run: |
+            COMMIT_HASH=$(git rev-parse --short HEAD)
+            echo "COMMIT_HASH=$COMMIT_HASH" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -48,3 +52,4 @@ jobs:
           labels: ${{ steps.metal.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: COMMIT_HASH=${{ env.COMMIT_HASH }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,10 @@ services:
       - BASE_URL=http://localhost:8080
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        - COMMIT_HASH=abcdefg
     image: ${IMAGE_NAME_FRONTEND}
     depends_on:
       - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:20.13.1
 WORKDIR /app
 
+ARG COMMIT_HASH
+ENV COMMIT_HASH=$COMMIT_HASH
+
 COPY ["package.json", ".npmrc", "./"]
 # Install pnpm
 RUN corepack enable pnpm

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,14 +1,12 @@
 import gitCommitInfo from 'git-commit-info';
 
+// When built in GitHub Actions, the commit hash is available in the environment, and gitCommitInfo won't find it.
+const commitHash = gitCommitInfo().shortHash ?? process.env.COMMIT_HASH;
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   devtools: { enabled: true },
-  modules: [
-    '@nuxt/image',
-    '@nuxtjs/i18n',
-    '@vite-pwa/nuxt',
-    '@nuxt/ui',
-  ],
+  modules: ['@nuxt/image', '@nuxtjs/i18n', '@vite-pwa/nuxt', '@nuxt/ui'],
   pwa: {},
   nitro: {
     prerender: {
@@ -19,7 +17,7 @@ export default defineNuxtConfig({
   vite: {},
   runtimeConfig: {
     public: {
-      commitHash: gitCommitInfo().shortHash,
+      commitHash,
       buildDate: new Date().toISOString(),
     },
   },


### PR DESCRIPTION
this is an attempt to get the commit hash during the pipeline, then pass it as an argument to the container to set as environment, which will be persisted in the resulting image

closes #643